### PR TITLE
Enable applesmc for qemu

### DIFF
--- a/SOURCES/build-configuration.patch
+++ b/SOURCES/build-configuration.patch
@@ -93,6 +93,7 @@ index 4cc64dafa2..f2024c9aa3 100644
 +CONFIG_USB_UHCI=y
 +CONFIG_VGA_CIRRUS=y
 +CONFIG_VGA_PCI=y
++CONFIG_APPLESMC=y
 diff --git a/hw/Makefile.objs b/hw/Makefile.objs
 index 66eef20561..efc8663d75 100644
 --- a/hw/Makefile.objs

--- a/SOURCES/build-configuration.patch
+++ b/SOURCES/build-configuration.patch
@@ -59,7 +59,7 @@ diff --git a/default-configs/i386-softmmu.mak b/default-configs/i386-softmmu.mak
 index 4cc64dafa2..f2024c9aa3 100644
 --- a/default-configs/i386-softmmu.mak
 +++ b/default-configs/i386-softmmu.mak
-@@ -25,7 +25,30 @@
+@@ -25,7 +25,31 @@
  
  # Boards:
  #


### PR DESCRIPTION
In order to virtualize MacOS on xcp-ng, we might need that applesmc support for qemu compiled in.  

See https://xcp-ng.org/forum/topic/3465/osx-on-mac-mini-on-xcp-ng/10 